### PR TITLE
Query strings do not respect the `shouldTypecast` property

### DIFF
--- a/dev/src/intro.js
+++ b/dev/src/intro.js
@@ -72,14 +72,14 @@
     }
 
     //borrowed from AMD-Utils
-    function decodeQueryString(str) {
+    function decodeQueryString(str, shouldTypecast) {
         var queryArr = (str || '').replace('?', '').split('&'),
             n = queryArr.length,
             obj = {},
             item, val;
         while (n--) {
             item = queryArr[n].split('=');
-            val = typecastValue(item[1]);
+            val = shouldTypecast ? typecastValue(item[1]) : item[1];
             obj[item[0]] = (typeof val === 'string')? decodeURIComponent(val) : val;
         }
         return obj;

--- a/dev/src/route.js
+++ b/dev/src/route.js
@@ -89,7 +89,7 @@
                         o[param +'_'] = val;
                         //update vals_ array as well since it will be used
                         //during dispatch
-                        val = decodeQueryString(val);
+                        val = decodeQueryString(val, shouldTypecast);
                         values[n] = val;
                     }
                     // IE will capture optional groups as empty strings while other

--- a/dev/tests/spec/match.spec.js
+++ b/dev/tests/spec/match.spec.js
@@ -586,7 +586,11 @@ describe('Match', function(){
             });
 
             it('should validate with Function', function () {
+                var prevTypecast = crossroads.shouldTypecast;
                 var r = crossroads.addRoute('/foo.php{?query}');
+
+                crossroads.shouldTypecast = true;
+
                 r.rules = {
                     '?query' : function(val, req, vals){
                         return (val.lorem === 'ipsum' && typeof val.dolor === 'number');
@@ -595,6 +599,8 @@ describe('Match', function(){
                 expect( r.match('foo.php?bar=123&ipsum=dolor') ).toBe( false );
                 expect( r.match('foo.php?lorem=ipsum&dolor=12345') ).toBe( true );
                 expect( r.match('foo.php?lorem=ipsum&dolor=amet') ).toBe( false );
+
+                crossroads.shouldTypecast = prevTypecast; //restore
             });
 
         });

--- a/dev/tests/spec/parse.spec.js
+++ b/dev/tests/spec/parse.spec.js
@@ -906,6 +906,9 @@ describe('crossroads.parse()', function(){
 
         describe('required query string after required segment', function () {
             it('should parse query string into an object and typecast vals', function () {
+                var prevTypecast = crossroads.shouldTypecast;
+                crossroads.shouldTypecast = true;
+
                 var r = crossroads.addRoute('{a}{?b}');
                 var t1, t2;
                 r.matched.addOnce(function(a, b){
@@ -916,11 +919,16 @@ describe('crossroads.parse()', function(){
 
                 expect( t1 ).toEqual( 'foo.php' );
                 expect( t2 ).toEqual( {lorem : 'ipsum', asd : 123, bar : false} );
+
+                crossroads.shouldTypecast = prevTypecast; //restore
             });
         });
 
         describe('required query string after optional segment', function () {
             it('should parse query string into an object and typecast vals', function () {
+                var prevTypecast = crossroads.shouldTypecast;
+                crossroads.shouldTypecast = true;
+
                 var r = crossroads.addRoute(':a:{?b}');
                 var t1, t2;
                 r.matched.addOnce(function(a, b){
@@ -941,11 +949,16 @@ describe('crossroads.parse()', function(){
 
                 expect( t3 ).toBeUndefined();
                 expect( t4 ).toEqual( {lorem : 'ipsum', asd : 123} );
+
+                crossroads.shouldTypecast = prevTypecast; //restore
             });
         });
 
         describe('optional query string after required segment', function () {
             it('should parse query string into an object and typecast vals', function () {
+                var prevTypecast = crossroads.shouldTypecast;
+                crossroads.shouldTypecast = true;
+
                 var r = crossroads.addRoute('{a}:?b:');
                 var t1, t2;
                 r.matched.addOnce(function(a, b){
@@ -966,11 +979,16 @@ describe('crossroads.parse()', function(){
 
                 expect( t3 ).toEqual( 'bar.php' );
                 expect( t4 ).toBeUndefined();
+
+                crossroads.shouldTypecast = prevTypecast; //restore
             });
         });
 
         describe('optional query string after optional segment', function () {
             it('should parse query string into an object and typecast vals', function () {
+                var prevTypecast = crossroads.shouldTypecast;
+                crossroads.shouldTypecast = true;
+
                 var r = crossroads.addRoute(':a::?b:');
                 var t1, t2;
                 r.matched.addOnce(function(a, b){
@@ -991,9 +1009,26 @@ describe('crossroads.parse()', function(){
 
                 expect( t3 ).toEqual( 'bar.php' );
                 expect( t4 ).toBeUndefined();
+
+                crossroads.shouldTypecast = prevTypecast; //restore
             });
         });
 
+        describe('optional query string after required segment without typecasting', function () {
+            it('should parse query string into an object and not typecast vals', function () {
+                var r = crossroads.addRoute('{a}:?b:');
+                var t1, t2;
+
+                r.matched.addOnce(function(a, b){
+                    t1 = a;
+                    t2 = b;
+                });
+                crossroads.parse('foo.php?lorem=ipsum&asd=123&bar=false');
+
+                expect( t1 ).toEqual( 'foo.php' );
+                expect( t2 ).toEqual( {lorem : 'ipsum', asd : '123', bar : 'false'} );
+            });
+        });
     });
 
 


### PR DESCRIPTION
This patch changes the decoding of query strings to respect the global `shouldTypecast` property.

I could tell from your unit tests that typecasting the query string values was intentional, but I feel this is a bit unexpected when I explicitly set the `shouldTypecast` property to `false`. For this reason I'm hoping you will consider accepting this patch which makes the behaviour consistent.

I've updated all the unit tests that test the typecasting of query strings and added a new one that tests that typecasting is not performed by default. All tests pass after these changes.
